### PR TITLE
enabling other organisms

### DIFF
--- a/R/enrichPathway.R
+++ b/R/enrichPathway.R
@@ -199,7 +199,8 @@ TERM2NAME.Reactome <- function(term, organism, ...) {
 
     pathName <- sapply(pathName, function(p) p[grep(org, p)])
     pathName <- unlist(pathName)
-    pathName <- sapply(pathName, function(i) unlist(strsplit(i, split=": "))[2])
+    pathName <- sapply(pathName, function(i) unlist(strsplit(i, split=org))[2]) # splitting by ":" is risky
+    pathName <- sub("^\\s+", "", pathName)  # remove leading spaces
 
     ##
     ## BUG was reported by Jean-Christophe Aude (Jean-Christophe.AUDE@cea.fr)

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -50,7 +50,7 @@ viewPathway <- function(pathName,
                         yeast="scerevisiae",
                         zebrafish="drerio")
     if(!(organism %in% names(org2org))){
-        cat(paste(c("the list of supported organisms:",names(org2org),'\n'), collapse='\n'))
+        cat(paste(c("the list of supported organisms:",names(org2org)), collapse='\n'))
         stop(sprintf("organism %s is not supported", organism))
     }
     

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -59,14 +59,9 @@ viewPathway <- function(pathName,
     if (readable) {
         p <- convertIdentifiers(p, "symbol")
         if (!is.null(foldChange)) {
-            org.X.eg.db <- GOSemSim::getDb(organism) # GOSemSim imported through DOSE
-            org.X.egSYMBOL <- sub('.db', 'SYMBOL', org.X.eg.db)
-            symbol <- loadNamespace(org.X.eg.db)[[org.X.egSYMBOL]]
-            map <- as.list(symbol[names(geneList)])
-            stopifnot(all(sapply(map, length) == 1))
-            map <- unlist(map)
-            stopifnot(identical(names(map), names(foldChange)))
-            names(foldChange) <- map
+            stopifnot(!any(duplicated(names(foldChange)))) # can't have two value for one gene
+            names(foldChange) <- EXTID2NAME(names(foldChange), organism)
+
         }
     } else {
         if (!is.null(foldChange)) {

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -49,7 +49,7 @@ viewPathway <- function(pathName,
                         xenopus="xlaevis",
                         yeast="scerevisiae",
                         zebrafish="drerio")
-    if(organism %in% names(org2org)){
+    if(!(organism %in% names(org2org))){
         cat(paste(c("the list of supported organisms:",names(org2org),'\n'), collapse='\n'))
         stop(sprintf("organism %s is not supported", organism))
     }

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -59,7 +59,7 @@ viewPathway <- function(pathName,
     if (readable) {
         p <- convertIdentifiers(p, "symbol")
         if (!is.null(foldChange)) {
-            org.X.eg.db <- GoSemSim::getDb(organism) # GOSemSim imported through DOSE
+            org.X.eg.db <- GOSemSim::getDb(organism) # GOSemSim imported through DOSE
             org.X.egSYMBOL <- sub('.db', 'SYMBOL', org.X.eg.db)
             symbol <- loadNamespace(org.X.eg.db)[[org.X.egSYMBOL]]
             map <- as.list(symbol[names(geneList)])

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -33,7 +33,28 @@ viewPathway <- function(pathName,
     
     pkg <- "graphite"
     require(pkg, character.only=TRUE)
-    p <- pathways(organism, 'reactome')[[pathName]]
+    
+    # convertion to the names that graphite::pathways understands
+    org2org <- list(arabidopsis="athaliana",
+                        bovine="btaurus",
+                        canine="cfamiliaris",
+                        chicken="ggallus",
+                        ecolik12="ecoli",
+                        fly="dmelanogaster",
+                        human="hsapiens",
+                        mouse="mmusculus",
+                        pig="sscrofa",
+                        rat="rnorvegicus",
+                        celegans="celegans",
+                        xenopus="xlaevis",
+                        yeast="scerevisiae",
+                        zebrafish="drerio")
+    if(organism %in% names(org2org)){
+        cat(paste(c("the list of supported organisms:",names(org2org),'\n'), collapse='\n'))
+        stop(sprintf("organism %s is not supported", organism))
+    }
+    
+    p <- pathways(org2org[[organism]], 'reactome')[[pathName]]
 
     if (readable) {
         p <- convertIdentifiers(p, "symbol")

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -6,7 +6,7 @@
 ##' @param organism supported organism
 ##' @param readable logical
 ##' @param foldChange fold change
-##' @param ... additional parameter
+##' @param ... additional parameters passed to \code{\link[DOSE]{netplot}}
 ## @importFrom graphite pathways
 ##' @importFrom graphite convertIdentifiers
 ##' @importFrom graphite pathwayGraph
@@ -33,25 +33,19 @@ viewPathway <- function(pathName,
     
     pkg <- "graphite"
     require(pkg, character.only=TRUE)
-    pathways <- eval(parse(text="pathways"))
-    ## convertIdentifiers <- eval(parse(text="convertIdentifiers"))
-    ## pathwayGraph <- eval(parse(text="pathwayGraph"))
-    
-    
-    if (organism == "human") {
-        p <- pathways("hsapiens", "reactome")[[pathName]]
-        ## p@species
-    } else {
-        stop("the specific organism is not supported yet...")
-    }
-
-    
+    p <- pathways(organism, 'reactome')[[pathName]]
 
     if (readable) {
         p <- convertIdentifiers(p, "symbol")
-        if (!is.null(foldChange)){
-            gn <- EXTID2NAME(names(foldChange),organism)
-            names(foldChange) <- gn
+        if (!is.null(foldChange)) {
+            org.X.eg.db <- GoSemSim::getDb(organism) # GOSemSim imported through DOSE
+            org.X.egSYMBOL <- sub('.db', 'SYMBOL', org.X.eg.db)
+            symbol <- loadNamespace(org.X.eg.db)[[org.X.egSYMBOL]]
+            map <- as.list(symbol[names(geneList)])
+            stopifnot(all(sapply(map, length) == 1))
+            map <- unlist(map)
+            stopifnot(identical(names(map), names(foldChange)))
+            names(foldChange) <- map
         }
     } else {
         if (!is.null(foldChange)) {


### PR DESCRIPTION
may need explicitly add GOSemSim to Imports or expose getDb function (or similar function linking organism name to org.X.eg.db) in other way.   I'll add organism name conversion to make sure 'graphite' compatible with 'GOSemSim'.  E.g. homo sapiens is 'hsapiens' in 'graphite', but 'human' in 'GOSemSim'.
