### PR TITLE
Avoid using assign in setting ReactomePA's environment variable 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     AnnotationDbi,
     DOSE (>= 3.5.1),
     enrichplot,
-    ggplot2,
+    ggplot2 (>= 3.3.5),
     ggraph,
     reactome.db,
     igraph,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,5 @@ BugReports: https://github.com/GuangchuangYu/ReactomePA/issues
 Packaged: 2012-03-05 18:26:53 UTC; mcarlson
 biocViews: Pathways, Visualization, Annotation, MultipleComparison,
     GeneSetEnrichment, Reactome
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
+Encoding: UTF-8

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -58,12 +58,12 @@ gsePathway <- function(geneList,
     return(res)
 }
 
-
+# Create a new environment to avoid assignments to 
+# a user's global environment
+reactome_env <- new.env(parent = emptyenv())
 get_Reactome_Env <- function() {
-  # Create a new environment to avoid assignments to 
-  # a user's global environment
-  reactome_env <- new.env()
-    if (!exists(".ReactomePA_Env", envir = .GlobalEnv)) {
+
+    if (!exists(".ReactomePA_Env", envir = reactome_env)) {
         assign(".ReactomePA_Env", new.env(), reactome_env)
     }
     get(".ReactomePA_Env", envir= reactome_env)

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -60,10 +60,13 @@ gsePathway <- function(geneList,
 
 
 get_Reactome_Env <- function() {
+  # Create a new environment to avoid assignments to 
+  # a user's global environment
+  reactome_env <- new.env()
     if (!exists(".ReactomePA_Env", envir = .GlobalEnv)) {
-        assign(".ReactomePA_Env", new.env(), .GlobalEnv)
+        assign(".ReactomePA_Env", new.env(), reactome_env)
     }
-    get(".ReactomePA_Env", envir= .GlobalEnv)
+    get(".ReactomePA_Env", envir= reactome_env)
 }
 
 ##' @importMethodsFrom AnnotationDbi as.list

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -101,7 +101,7 @@ viewPathway <- function(pathName,
         scale_color_continuous(low="red", high="blue", name = "fold change", na.value = "#E5C494") +
         geom_node_text(aes_(label=~name), repel=TRUE) +
         ## scale_color_gradientn(name = "fold change", colors=palette, na.value = "#E5C494") +
-        scale_size(guide = FALSE) + theme_void()
+        scale_size(guide = "none") + theme_void()
 }
 
 

--- a/R/viewPathway.R
+++ b/R/viewPathway.R
@@ -8,7 +8,6 @@
 ##' @param foldChange fold change
 ##' @param keyType keyType of gene ID (i.e. names of foldChange, if available)
 ##' @param layout graph layout
-##' @param ... additional parameters
 ## @importFrom graphite pathways
 ##' @importFrom graphite convertIdentifiers
 ##' @importFrom graphite pathwayGraph
@@ -32,7 +31,7 @@ viewPathway <- function(pathName,
                         readable=TRUE,
                         foldChange=NULL,
                         keyType = "ENTREZID",
-                        layout = "kk", ...){
+                        layout = "kk"){
 
     ## call pathways via imported from graphite has the following issue:
     ##

--- a/man/viewPathway.Rd
+++ b/man/viewPathway.Rd
@@ -10,8 +10,7 @@ viewPathway(
   readable = TRUE,
   foldChange = NULL,
   keyType = "ENTREZID",
-  layout = "kk",
-  ...
+  layout = "kk"
 )
 }
 \arguments{
@@ -26,8 +25,6 @@ viewPathway(
 \item{keyType}{keyType of gene ID (i.e. names of foldChange, if available)}
 
 \item{layout}{graph layout}
-
-\item{...}{additional parameters}
 }
 \value{
 plot

--- a/vignettes/ReactomePA.Rmd
+++ b/vignettes/ReactomePA.Rmd
@@ -59,7 +59,7 @@ __*G Yu*__, QY He^\*^. ReactomePA: an R/Bioconductor package for reactome pathwa
 
 
 
-# Need helps?
+# Need help?
 
 
 If you have questions/issues, please post to [Bioconductor support site](https://support.bioconductor.org/) and tag your post with *ReactomePA*.


### PR DESCRIPTION
Hi,

This PR removes assignments to `.GlobalEnv` and instead using a new local environment within `gseAnalyzer`. This preserves functionality while avoiding [issues with assign](https://stackoverflow.com/questions/17559390/why-is-using-assign-bad). 

Thank you,
NelsonGon